### PR TITLE
Switching to tf2 for ROS noetic

### DIFF
--- a/rviz_mesh_display/src/mesh_display_custom.cpp
+++ b/rviz_mesh_display/src/mesh_display_custom.cpp
@@ -122,7 +122,7 @@ void MeshDisplayCustom::onInitialize()
     ImageDisplayBase::onInitialize();
 
     // it will only accept images if the frame in camera info is resolved
-    caminfo_tf_filter_ = new tf::MessageFilter<sensor_msgs::CameraInfo>( *context_->getTFClient(), fixed_frame_.toStdString(),
+    caminfo_tf_filter_ = new tf2_ros::MessageFilter<sensor_msgs::CameraInfo>( *context_->getTF2BufferPtr(), fixed_frame_.toStdString(),
                                                                          queue_size_property_->getInt(), update_nh_ );
 
     context_->getSceneManager()->addRenderQueueListener(this);

--- a/rviz_mesh_display/src/mesh_display_custom.h
+++ b/rviz_mesh_display/src/mesh_display_custom.h
@@ -46,7 +46,7 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <message_filters/subscriber.h>
-#include <tf/message_filter.h>
+#include <tf2_ros/message_filter.h>
 
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseStamped.h>
@@ -155,7 +155,7 @@ private:
 
   //This deals with the camera info
   message_filters::Subscriber<sensor_msgs::CameraInfo> caminfo_sub_;
-  tf::MessageFilter<sensor_msgs::CameraInfo>* caminfo_tf_filter_;
+  tf2_ros::MessageFilter<sensor_msgs::CameraInfo>* caminfo_tf_filter_;
 
   sensor_msgs::CameraInfo::ConstPtr current_caminfo_;
   boost::mutex caminfo_mutex_;


### PR DESCRIPTION
Rviz DisplayContext has migrated to tf2 in ROS Noetic, so I've simply adapted the message filter code to be tf2 compatible. Will likely address #1.

You may want to create a `noetic` branch first though.